### PR TITLE
Better debug string display

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,10 @@
         <div id="moduleData">
             <div class="mainColumn" id="disassembleDiv"></div>
             <div class="mainColumn" id="dagDiv">
+                <!-- used when wanting to view debug string text -->
+                <div id="debugStringDiv"></div>
+
+                <!-- Handles drawing and displaying the dag -->
                 <svg id="dagSvg"></svg>
 
                 <!-- On Load instructions - Will be removed from DOM later -->

--- a/input.js
+++ b/input.js
@@ -118,6 +118,13 @@ function operationOnClick(event) {
     displayDagOpcode(opcode, instruction);
 }
 
+function debugStringOnClick(event) {
+    var parent = event.target.parentElement;
+    // id will be of "instruction_x"
+    var instruction = parseInt(parent.id.substring(parent.id.indexOf("_")+1));
+    displayDebugString(instruction);
+}
+
 // Some settings are easier to reset than have stateful logic of inputs outside this file
 function resetSettings() {
     document.getElementById("opNames").checked = false;

--- a/style.css
+++ b/style.css
@@ -124,6 +124,12 @@
     color : orangered;
 }
 
+.debugString:hover {
+    color : blue;
+    font-weight: bold;
+    cursor: pointer;
+}
+
 .enumerant {
     color : orangered;
 }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+body {
+    /* prevent scroll bar for whole page */
+    overflow: hidden;
+}
+
 #mainModuleContainer {
     width: 99vw; /* 100 causes small scroll bar*/
     min-height: 100%;
@@ -15,7 +20,7 @@
 
 .mainColumn {
     float: left;
-    height: 89vh; /* prevent scroll bar for whole page */
+    height: 91vh;
     padding: .5%;
     margin-top: 0vh;
     border: 1px solid black;


### PR DESCRIPTION
some instructions such as `OpSource` will display large GLSL/HLSL source code and better off being displayed on the right screen dedicated and not squeezed in with the rest of the instructions