### PR TITLE
Add way to paste Disassembled SPIR-V as text

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,5 @@
 BasedOnStyle: Google
 IndentWidth: 4
 ColumnLimit: 132
+Language: JavaScript
 ...

--- a/index.html
+++ b/index.html
@@ -52,7 +52,10 @@
             </div>
         </div>
         <div id="moduleData">
-            <div class="mainColumn" id="disassembleDiv"></div>
+            <!-- Both these take left side of screen, only one is visiable at a time -->
+            <textarea class="mainColumn" id="disassembleInputDiv"></textarea>
+            <div class="mainColumn" id="disassembleDisplayDiv"></div>
+
             <div class="mainColumn" id="dagDiv">
                 <!-- used when wanting to view debug string text -->
                 <div id="debugStringDiv"></div>
@@ -69,6 +72,8 @@
                     Based on SPIR-V grammar <span id="spirvVersion"></span>
                     <h2>Select SPIR-V binary file to load</h2>
                     <input type="file" id="fileSelector">
+                    <h2>OR</h2>
+                    <h2>Paste SPIR-V disassembly on the left (and press enter)</h2>
                     <br><br><hr>
                     <h1>How to use</h1>
                     <img src="doc/instructions_0.png" alt="instructions_0.png">
@@ -84,6 +89,7 @@
   <script src="source/utils.js"></script>
   <script src="source/input.js"></script>
   <script src="source/spirv.js"></script>
+  <script src="source/assembler.js"></script>
   <script src="source/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </script>
   </head>
 
-  <body onload="loadSpirvJson()">
+  <body onload="loadSpirv('SPIRV-Headers/include/spirv/unified1/')">
 <!-- For Testing Only - at top to load first -->
 <!--
     <script>TEST_SUITE=true;</script>

--- a/source/assembler.js
+++ b/source/assembler.js
@@ -1,0 +1,248 @@
+// Copyright (c) 2023 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+/*
+This takes a string and turns it into a Uint32Array SPIR-V binary
+
+Details of the layout of a SPIR-V Instruction can be found at
+https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_physical_layout_of_a_spir_v_module_and_instruction
+*/
+function assemble(spirvText, version) {
+    let encoder = new TextEncoder();
+
+    let idMap = new Map();             // map text name to binary ID used [ %stringName, %1 ]
+    let bitWidthIntMap = new Map();    // map [ %stringName, width ] for OpConstants
+    let bitWidthFloatMap = new Map();  // map [ %stringName, width ] for OpConstants
+
+    let extInstructionSets = new Map();
+    let lastOpExtInst = 0;
+
+    // SPIR-V Header
+    let words = [
+        spirv.Meta.MagicNumber, (version == undefined) ? SPV_ENV_UNIVERSAL_1_0 : version,
+        0x0,  // generator
+        0x0,  // ID Bounds - update later
+        0x0,  // reserved
+    ];
+
+    // first ID in SPIR-V is %1 (not %0)
+    let idsBound = 1;
+
+    // Make life easy, assume every instruction is a single line
+    spirvText.split('\n').forEach(line => {
+        // If there is a Literal String, capture it to use later
+        let literalString = undefined;
+        const quoteStart = line.indexOf('"')
+        let extraWords = 0;
+        if (quoteStart != -1) {
+            const quoteEnd = line.lastIndexOf('"');
+            literalString = line.substring(quoteStart + 1, quoteEnd) + '\0';
+            // Substract 1 because there is already 1 word accounted for the string in line
+            extraWords = Math.ceil(literalString.length / 4) - 1;
+            // Just need to replace whitespaces here so the split() works as intended
+            line.replace(literalString, '/\s+/g, \'\'');
+        }
+
+        // regex to remove all duplicated white space
+        // This makes the 'line' be an array of all words\
+        line = line.trim().replace(/\s{2,}/g, ' ').split(' ');
+        if (line.length == 1 && line[0] == '') {
+            return;
+        }  // empty line
+        if (line[0] == ';') {
+            return;
+        }  // SPIR-V comment
+
+        const hasResult = line.length >= 3 && line[1] == '=';
+        if (hasResult) {
+            if (idMap.get(line[0]) == undefined) {
+                idMap.set(line[0], idsBound++);
+            }
+        }
+
+        const instructionLength = (hasResult ? line.length - 1 : line.length) + extraWords;
+
+        const opname = hasResult ? line[2] : line[0];
+        const opcode = spirv.NameToOpcode.get(opname);
+        words.push((instructionLength << spirv.Meta.WordCountShift) | (opcode));
+
+        let operandIndex = 0;  // Which binary operand at
+        let lineIndex = 1;     // Which text word at (default if not Type/Result)
+
+        // When looping operands, can use to easily stop parsing for Wildcard that have zero entries
+        const lastWord = (words.length - 1) + instructionLength;
+
+        const hasResultType = spirv.OpcodesWithResultType.includes(opcode);
+        if (hasResultType) {
+            operandIndex++;
+            lineIndex++;
+            const resultType = hasResult ? line[3] : line[1];
+            words.push(idMap.get(resultType));
+        }
+
+        if (hasResult) {
+            operandIndex++;
+            lineIndex += 2;
+            words.push(idMap.get(line[0]));
+        }
+
+        // Special instructions need to track
+        if (opname == 'OpExtInstImport') {
+            extInstructionSets.set(idMap.get(line[0]), spirv.getExtInstructions(line[3]));
+        } else if (opname == 'OpExtInst') {
+            lastOpExtInst = idMap.get(line[4]);
+        } else if (opname == 'OpTypeInt') {
+            bitWidthIntMap.set(idMap.get(line[0]), line[3]);
+        } else if (opname == 'OpTypeFloat') {
+            bitWidthFloatMap.set(idMap.get(line[0]), line[3]);
+        }
+
+        // Some operands need to call a few levels of recursion if they have parameters
+        function GetOperand(kind) {
+            if (kind == 'IdRef' || kind == 'IdScope' || kind == 'IdMemorySemantics') {
+                // Just need the <ID> being used
+                let id = idMap.get(line[lineIndex]);
+                if (id == undefined) {
+                    // Mode Setting / Debug / Annotations
+                    // instructions will not know what id value is given yet
+                    words.push(idsBound);
+                    idMap.set(line[lineIndex], idsBound++);
+                } else {
+                    words.push(id);
+                }
+                lineIndex++
+            } else if (kind == 'LiteralExtInstInteger') {
+                const extInstructionSet = extInstructionSets.get(lastOpExtInst);
+                for (let [extOpcode, extInstruction] of extInstructionSet) {
+                    if (extInstruction.opname == line[lineIndex]) {
+                        lineIndex++
+                        words.push(extOpcode);
+                        if (extInstruction.operands) {
+                            for (let i = 0; i < extInstruction.operands.length; i++) {
+                                const extKind = extInstruction.operands[i].kind;
+                                GetOperand(extKind);
+                            }
+                        }
+                        return;
+                    }
+                }
+            } else if (kind == 'LiteralInteger' || kind == 'LiteralSpecConstantOpInteger') {
+                words.push(parseInt(line[lineIndex++]));
+            } else if (kind == 'LiteralContextDependentNumber') {
+                const typeId = idMap.get(line[lineIndex - 1])
+                const bitWidthInt = parseInt(bitWidthIntMap.get(typeId));
+                const bitWidthFloat = parseInt(bitWidthFloatMap.get(typeId));
+                if (bitWidthInt == 64) {
+                    const value = BigInt(line[lineIndex++]);
+                    words.push(parseInt(value & BigInt(0xffffffff)));
+                    words.push(parseInt(value >> BigInt(32)));
+                } else if (bitWidthFloat == 32) {
+                    let view = new DataView(new ArrayBuffer(4));
+                    view.setFloat32(0, line[lineIndex++]);
+                    words.push(view.getUint32(0));
+                } else if (bitWidthFloat == 64) {
+                    let view = new DataView(new ArrayBuffer(8));
+                    view.setFloat64(0, line[lineIndex++]);
+                    words.push(view.getUint32(4));
+                    words.push(view.getUint32(0));
+                } else {
+                    words.push(Number(line[lineIndex++]));
+                }
+
+                // TODO - Need a better way to do this
+                // Go back and update length of instruction
+                if (bitWidthInt == 64 || bitWidthFloat == 64) {
+                    let instruction = words[words.length - 5];
+                    words[words.length - 5] = (((instruction >> 16) + 1) << 16) | (instruction & 0xffff);
+                }
+            } else if (kind == 'PairLiteralIntegerIdRef') {
+                words.push(parseInt(line[lineIndex++]));
+                words.push(idMap.get(line[lineIndex++]));
+            } else if (kind == 'PairIdRefLiteralInteger') {
+                words.push(idMap.get(line[lineIndex++]));
+                words.push(parseInt(line[lineIndex++]));
+            } else if (kind == 'PairIdRefIdRef') {
+                words.push(idMap.get(line[lineIndex++]));
+                words.push(idMap.get(line[lineIndex++]));
+            } else if (kind == 'LiteralString') {
+                let bytes = encoder.encode(literalString);
+                // turn Uint8Array to Uint32Array
+                for (let i = 0; i < bytes.length; i += 4) {
+                    // Can OOB array index because OR operations with 'undefined' is same as OR with zero
+                    const word = bytes[i + 3] << 24 | bytes[i + 2] << 16 | bytes[i + 1] << 8 | bytes[i + 0];
+                    words.push(word);
+                }
+            } else {
+                const operandInfo = spirv.Operands.get(kind);
+                if (!operandInfo.enumerants) {
+                    console.log('ERROR: Unhandled kind of ' + kind);
+                }
+
+                // If not BitEnum, it is a ValueEnum
+                const isBitEnum = (operandInfo.category == 'BitEnum');
+                const value = isBitEnum ? line[lineIndex].split('|') : line[lineIndex];
+                // If BitEnum, need to update value later on
+                const enumValueIndex = words.length;
+                words.push(0);  // placeholder
+                lineIndex++;
+
+                for (let i = 0; i < operandInfo.enumerants.length; i++) {
+                    const enumerant = operandInfo.enumerants[i];
+                    if (isBitEnum && value.includes(enumerant.enumerant)) {
+                        words[enumValueIndex] |= parseInt(enumerant.value);
+                    } else if (!isBitEnum && value == enumerant.enumerant) {
+                        words[enumValueIndex] = enumerant.value;
+                    } else {
+                        continue;
+                    }
+
+                    if (enumerant.parameters) {
+                        for (let j = 0; j < enumerant.parameters.length; j++) {
+                            const parameterKind = enumerant.parameters[j].kind;
+                            GetOperand(parameterKind);
+                        }
+                    }
+                }
+            }
+        }
+
+        const instructionInfo = spirv.Instructions.get(opcode);
+        if (instructionInfo.operands == undefined) {
+            return;  // things like OpFunctionEnd
+        }
+
+        // Need to go through each operand
+        let isWildcard = false;
+        let kind = '';
+        while (operandIndex < instructionInfo.operands.length && (words.length < lastWord)) {
+            const operand = instructionInfo.operands[operandIndex];
+            kind = operand.kind;
+            isWildcard = operand.quantifier == '*';
+            GetOperand(kind);
+            operandIndex++
+        }
+
+        // If at end with wildcard, need to just reuse the same 'kind' for rest of line
+        while (isWildcard && (words.length < lastWord)) {
+            GetOperand(kind);
+            operandIndex++
+        }
+    });
+
+    // update the header
+    words[3] = idsBound;
+
+    return new Uint32Array(words);
+}

--- a/source/input.js
+++ b/source/input.js
@@ -19,6 +19,7 @@
 
 // Load in file
 function fileSelected(data, filename) {
+    toggleDisassemblyInput(false);
     if (filename == undefined) {
         filename = 'unknown';
     }
@@ -44,7 +45,7 @@ const fileSelectorTop = document.getElementById('fileSelectorTop');
 function fileSelect(event) {
     const reader = new FileReader();
     reader.onload = function() {
-        var filename = (event.target.files) ? event.target.files[0].name : undefined;
+        const filename = (event.target.files) ? event.target.files[0].name : undefined;
         fileSelected(reader.result, filename);
     };
     reader.readAsArrayBuffer(event.target.files[0]);
@@ -74,7 +75,7 @@ function dropHandler(event) {
     }
     const reader = new FileReader();
     reader.onload = function() {
-        filename = (file) ? file.name : undefined;
+        const filename = (file) ? file.name : undefined;
         fileSelected(reader.result, filename);
     };
     reader.readAsArrayBuffer(file);
@@ -132,8 +133,31 @@ function resetSettings() {
     document.getElementById('insertConstants').checked = false;
 }
 
+function toggleDisassemblyInput(turnOn) {
+    if (turnOn) {
+        displayDiv.style.display = 'none';
+        inputDiv.style.display = 'inline-block';
+    } else {
+        displayDiv.style.display = 'inline-block';
+        inputDiv.style.display = 'none';
+        inputDiv.innerHTML = ''
+    }
+}
+
 // Sends all checkboxes out to handlers
 $(document).ready(function() {
+    // On start up
+    toggleDisassemblyInput(true);
+
+    $('#disassembleInputDiv').on('keypress', function(event) {
+        // Prevents shift+enter from starting event
+        if (event.which === 13 && !event.shiftKey) {
+            event.preventDefault();
+            const spirvBinary = assemble(inputDiv.value);
+            fileSelected(spirvBinary, 'disassembled text')
+        }
+    });
+
     $('input[type="checkbox"]').click(function() {
         let box = $(this)[0].name;
         let checked = $(this).prop('checked');

--- a/source/main.js
+++ b/source/main.js
@@ -15,7 +15,8 @@
 
 // Grab all DOM objects
 
-const disassembleDiv = document.getElementById('disassembleDiv');
+var displayDiv = document.getElementById('disassembleDisplayDiv');
+var inputDiv = document.getElementById('disassembleInputDiv');
 
 // Main map of all items with instruction index as key
 var instructionMap = new Map();
@@ -46,7 +47,7 @@ function parseBinaryStream(binary) {
     const performanceStart = performance.now();
 
     // Clear div from any previous run
-    disassembleDiv.innerHTML = '';
+    displayDiv.innerHTML = '';
     // clear previous SVG
     d3.select('#dagSvg').selectAll('*').remove();
     resetTracking();
@@ -74,10 +75,10 @@ function parseBinaryStream(binary) {
     // all instructions before first function are by themselves in "preFunciton" which is broken into 4 sections
     // Set preFunction div the same way as a normal function
     var preFunctionDiv = document.createElement('div');
-    addCollapsibleWrapper(preFunctionDiv, disassembleDiv, 'preFunction', 'modeSetting', 'Mode Setting');
+    addCollapsibleWrapper(preFunctionDiv, displayDiv, 'preFunction', 'modeSetting', 'Mode Setting');
 
     // div hierarchy
-    // disassembleDiv -> function -> label -> instructions
+    // displayDiv -> function -> label -> instructions
     var currentInstructionDiv = preFunctionDiv;
     var currentFunctionDiv = undefined;
 
@@ -117,17 +118,17 @@ function parseBinaryStream(binary) {
         if (insertedDebug == false && instructionInfo.class == 'Debug') {
             insertedDebug = true;
             let commentDiv = document.createElement('div');
-            addCollapsibleWrapper(commentDiv, disassembleDiv, 'preFunction', 'debug', 'Debug Information');
+            addCollapsibleWrapper(commentDiv, displayDiv, 'preFunction', 'debug', 'Debug Information');
             currentInstructionDiv = commentDiv;
         } else if (insertedAnnotation == false && instructionInfo.class == 'Annotation') {
             insertedAnnotation = true;
             let commentDiv = document.createElement('div');
-            addCollapsibleWrapper(commentDiv, disassembleDiv, 'preFunction', 'annotations', 'Annotations');
+            addCollapsibleWrapper(commentDiv, displayDiv, 'preFunction', 'annotations', 'Annotations');
             currentInstructionDiv = commentDiv;
         } else if (insertedType == false && instructionInfo.class == 'Type-Declaration') {
             insertedType = true;
             let commentDiv = document.createElement('div');
-            addCollapsibleWrapper(commentDiv, disassembleDiv, 'preFunction', 'types', 'Types, variables and constants');
+            addCollapsibleWrapper(commentDiv, displayDiv, 'preFunction', 'types', 'Types, variables and constants');
             currentInstructionDiv = commentDiv;
         }
 
@@ -154,7 +155,7 @@ function parseBinaryStream(binary) {
                     currentFunction.start = instructionCount;
 
                     var newDiv = document.createElement('div');
-                    addCollapsibleWrapper(newDiv, disassembleDiv, 'function', instructionCount, 'Function ' + instructionCount);
+                    addCollapsibleWrapper(newDiv, displayDiv, 'function', instructionCount, 'Function ' + instructionCount);
 
                     currentFunctionDiv = newDiv;
                     currentInstructionDiv = newDiv;

--- a/source/main.js
+++ b/source/main.js
@@ -57,7 +57,7 @@ function parseBinaryStream(binary) {
 
     assert(module.length >= 5, 'module less than 5 dwords which is the size of the header');
 
-    validateHeader(module.slice(0, 5));
+    spirv.validateHeader(module.slice(0, 5));
     const maxIdBound = module[3];
     for (let i = 0; i < maxIdBound; i++) {
         idConsumers[i] = [];
@@ -102,16 +102,16 @@ function parseBinaryStream(binary) {
 
     // First pass
     for (let i = 5; i < module.length;) {
-        var instruction = module[i];
-        var instructionLength = instruction >> spirvMeta.WordCountShift;
-        var opcode = instruction & spirvMeta.OpCodeMask;
+        const instruction = module[i];
+        const instructionLength = instruction >> spirv.Meta.WordCountShift;
+        const opcode = instruction & spirv.Meta.OpCodeMask;
 
         // Get type and result according to instruction layout
-        var hasResultType = opcodeHasResultType(opcode);
-        var hasResult = opcodeHasResult(opcode);
-        var opcodeResultType = hasResultType ? module[i + 1] : undefined;
-        var opcodeResult = hasResult ? (hasResultType ? module[i + 2] : module[i + 1]) : undefined;
-        var instructionInfo = spirvInstruction.get(opcode);
+        const hasResultType = spirv.OpcodesWithResultType.includes(opcode);
+        const hasResult = spirv.OpcodesWithResult.includes(opcode);
+        const opcodeResultType = hasResultType ? module[i + 1] : undefined;
+        const opcodeResult = hasResult ? (hasResultType ? module[i + 2] : module[i + 1]) : undefined;
+        var instructionInfo = spirv.Instructions.get(opcode);
         // Holds operands that are an id (non-literals)
         var operandIdList = [];
 
@@ -138,11 +138,11 @@ function parseBinaryStream(binary) {
             // Manage indent level from nested cfg
             // Need to be done prior to label getting assigned CSS style
             switch (opcode) {
-                case spirvEnum.Op.OpLoopMerge:
-                case spirvEnum.Op.OpSelectionMerge:
+                case spirv.Enums.Op.OpLoopMerge:
+                case spirv.Enums.Op.OpSelectionMerge:
                     indentStack.push(module[i + 1]);
                     break;
-                case spirvEnum.Op.OpLabel:
+                case spirv.Enums.Op.OpLabel:
                     if (indentStack[indentStack.length - 1] == module[i + 1]) {
                         indentStack.pop();
                     }
@@ -152,7 +152,7 @@ function parseBinaryStream(binary) {
 
             // Map the boundaries for functions and blocks
             switch (opcode) {
-                case spirvEnum.Op.OpFunction:
+                case spirv.Enums.Op.OpFunction:
                     currentFunction.start = instructionCount;
 
                     var newDiv = document.createElement('div');
@@ -161,13 +161,13 @@ function parseBinaryStream(binary) {
                     currentFunctionDiv = newDiv;
                     currentInstructionDiv = newDiv;
                     break;
-                case spirvEnum.Op.OpFunctionEnd:
+                case spirv.Enums.Op.OpFunctionEnd:
                     currentFunction.end = instructionCount;
 
                     // Label has ended and need to add last instruction
                     currentInstructionDiv = currentFunctionDiv
                     break;
-                case spirvEnum.Op.OpLabel:
+                case spirv.Enums.Op.OpLabel:
                     currentBlock.start = instructionCount;
                     currentBlock.function = currentFunction.start;
 
@@ -183,14 +183,14 @@ function parseBinaryStream(binary) {
 
                     currentInstructionDiv = newDiv;
                     break;
-                case spirvEnum.Op.OpBranch:
-                case spirvEnum.Op.OpBranchConditional:
-                case spirvEnum.Op.OpSwitch:
-                case spirvEnum.Op.OpReturn:
-                case spirvEnum.Op.OpReturnValue:
-                case spirvEnum.Op.OpKill:
-                case spirvEnum.Op.OpUnreachable:
-                case spirvEnum.Op.TerminateInvocation:
+                case spirv.Enums.Op.OpBranch:
+                case spirv.Enums.Op.OpBranchConditional:
+                case spirv.Enums.Op.OpSwitch:
+                case spirv.Enums.Op.OpReturn:
+                case spirv.Enums.Op.OpReturnValue:
+                case spirv.Enums.Op.OpKill:
+                case spirv.Enums.Op.OpUnreachable:
+                case spirv.Enums.Op.TerminateInvocation:
                     currentBlock.end = instructionCount;
                     break;
             };
@@ -198,14 +198,14 @@ function parseBinaryStream(binary) {
             // Build branching map
             var branchDestinations = [];
             switch (opcode) {
-                case spirvEnum.Op.OpBranch:
+                case spirv.Enums.Op.OpBranch:
                     branchDestinations.push(module[i + 1]);
                     break;
-                case spirvEnum.Op.OpBranchConditional:
+                case spirv.Enums.Op.OpBranchConditional:
                     branchDestinations.push(module[i + 2]);
                     branchDestinations.push(module[i + 3]);
                     break;
-                case spirvEnum.Op.OpSwitch:
+                case spirv.Enums.Op.OpSwitch:
                     branchDestinations.push(module[i + 2]);
                     for (let operand = 4; operand < instructionLength; operand += 2) {
                         branchDestinations.push(module[i + operand]);
@@ -218,8 +218,8 @@ function parseBinaryStream(binary) {
         }
 
         // Map extended instruction to result hashmap
-        if (opcode == spirvEnum.Op.OpExtInstImport) {
-            var extendedName = getLiteralString(module.slice(i + 2, i + instructionLength));
+        if (opcode == spirv.Enums.Op.OpExtInstImport) {
+            var extendedName = spirv.getLiteralString(module.slice(i + 2, i + instructionLength));
             if (extendedName == 'GLSL.std.450') {
                 resultToExtInstructionName.set(opcodeResult, ExtInstTypeGlslStd450);
             } else if (extendedName == 'OpenCL.std') {
@@ -250,7 +250,7 @@ function parseBinaryStream(binary) {
                 resultToInstructionMap.set(opcodeResult, instructionCount);
             }
 
-            instructionString += ' <a class="operation">' + mapValueToEnumKey(spirvEnum.Op, opcode) + '</a>'
+            instructionString += ' <a class="operation">' + mapValueToEnumKey(spirv.Enums.Op, opcode) + '</a>'
 
             if (hasResultType == true) {
                 instructionString += ' ' + createIdHtmlString(opcodeResultType, 'resultType');
@@ -377,10 +377,10 @@ function parseBinaryStream(binary) {
                     }
 
                 } else if (kind == 'LiteralString') {
-                    var literalString = getLiteralString(module.slice(i + operandOffset, i + instructionLength));
+                    var literalString = spirv.getLiteralString(module.slice(i + operandOffset, i + instructionLength));
                     // Source strings can be unhelpfully long, so hide by default
-                    if (opcode == spirvEnum.Op.OpSource || opcode == spirvEnum.Op.OpSourceContinued ||
-                        opcode == spirvEnum.Op.OpModuleProcessed) {
+                    if (opcode == spirv.Enums.Op.OpSource || opcode == spirv.Enums.Op.OpSourceContinued ||
+                        opcode == spirv.Enums.Op.OpModuleProcessed) {
                         debugStringMap.set(instructionCount, literalString);
                         instructionString += ' <span class="operand literal debugString">'
                         instructionString += 'click to view'
@@ -402,19 +402,19 @@ function parseBinaryStream(binary) {
 
                 } else if (kind == 'LiteralExtInstInteger') {
                     assert(
-                        opcode == spirvEnum.Op.OpExtInst, 'Makes assumption OpExtInst is only opcode with LiteralExtInstInteger');
+                        opcode == spirv.Enums.Op.OpExtInst, 'Makes assumption OpExtInst is only opcode with LiteralExtInstInteger');
                     // single word literal but from extended instruction set
                     var set = module[i + 3];
                     var extendedSet = resultToExtInstructionName.get(set);
 
                     // This will have the while loop use the extended grammar
-                    extendedOperandInfo = spirvExtInst.get(extendedSet).get(operand);
+                    extendedOperandInfo = spirv.ExtInstructions.get(extendedSet).get(operand);
                     instructionString += ' ' + createLiteralHtmlString(extendedOperandInfo.opname);
                     operandNameList.push(operandName);
                     operandOffset++;
 
                 } else if (kind == 'LiteralSpecConstantOpInteger') {
-                    specConstantOpInfo = spirvInstruction.get(module[i + operandOffset]);
+                    specConstantOpInfo = spirv.Instructions.get(module[i + operandOffset]);
                     instructionString += ' ' + createLiteralHtmlString(specConstantOpInfo.opname);
                     operandNameList.push(operandName);
                     operandOffset++;
@@ -427,10 +427,10 @@ function parseBinaryStream(binary) {
                     // Handle any opcodes that have context dependent operands
                     var width = 1;
                     var operandValue = operand;
-                    if (opcode == spirvEnum.Op.OpConstant || opcode == spirvEnum.Op.OpSpecConstant) {
+                    if (opcode == spirv.Enums.Op.OpConstant || opcode == spirv.Enums.Op.OpSpecConstant) {
                         // Result Type must be a scalar integer type or floating-point type.
                         var contextInstruction = instructionMap.get(resultToInstructionMap.get(module[i + 1]));
-                        if (contextInstruction.opcode == spirvEnum.Op.OpTypeInt) {
+                        if (contextInstruction.opcode == spirv.Enums.Op.OpTypeInt) {
                             var signedness = module[contextInstruction.moduleOffset + 3];
                             if (signedness == 1) {
                                 // JS way to bring uint32 to int32
@@ -447,7 +447,7 @@ function parseBinaryStream(binary) {
                                 // use toString to get rid of suffix from types of BigInt
                                 operandValue = ((BigInt(operandValueHigh) << BigInt(32)) + BigInt(operandValueLow)).toString();
                             }
-                        } else if (contextInstruction.opcode == spirvEnum.Op.OpTypeFloat) {
+                        } else if (contextInstruction.opcode == spirv.Enums.Op.OpTypeFloat) {
                             // 4 instrutions is a normal 32 bit width, extra instruction length is another byte
                             width = instructionLength - 3;
                             assert(width <= 2, 'parsing ' + 32 * width + ' bit float is not supported');
@@ -472,7 +472,7 @@ function parseBinaryStream(binary) {
                     }
 
                     var insertValue = operandValue;
-                    if (opcode == spirvEnum.Op.OpSpecConstant) {
+                    if (opcode == spirv.Enums.Op.OpSpecConstant) {
                         insertValue = 'spec(' + insertValue + ')';
                     }
                     constantValues.set(module[i + 2], insertValue);
@@ -495,7 +495,7 @@ function parseBinaryStream(binary) {
                     while (operandOffset < instructionLength) {
                         var nextOperand = module[i + operandOffset];
                         var nextNextOperand = module[i + operandOffset + 1];
-                        if (opcode == spirvEnum.Op.OpSwitch) {
+                        if (opcode == spirv.Enums.Op.OpSwitch) {
                             instructionString += ' (Case ';
                             instructionString += createLiteralHtmlString(nextOperand);
                             instructionString += ' : ';
@@ -508,7 +508,7 @@ function parseBinaryStream(binary) {
                             operandNameList.push('Case');
                             operandNameList.push('Id');
                         }
-                        if (opcode == spirvEnum.Op.OpGroupMemberDecorate) {
+                        if (opcode == spirv.Enums.Op.OpGroupMemberDecorate) {
                             instructionString += ' (';
                             instructionString += createIdHtmlString(nextOperand, 'operand');
                             instructionString += ' : ';
@@ -521,7 +521,7 @@ function parseBinaryStream(binary) {
                             operandNameList.push('Id ' + quantifierIndex);
                             operandNameList.push('Member ' + quantifierIndex);
                         }
-                        if (opcode == spirvEnum.Op.OpPhi) {
+                        if (opcode == spirv.Enums.Op.OpPhi) {
                             instructionString += ' (';
                             instructionString += createIdHtmlString(nextOperand, 'operand');
                             instructionString += ' : ';
@@ -540,12 +540,12 @@ function parseBinaryStream(binary) {
                         quantifierIndex++;
                     }
                 } else {
-                    operandInfo = spirvOperand.get(kind);
+                    operandInfo = spirv.Operands.get(kind);
                     // If extended instruction might need to check grammar file
                     if (!operandInfo && extendedOperandInfo) {
                         var set = module[i + 3];
                         var extendedSet = resultToExtInstructionName.get(set);
-                        operandInfo = spirvExtOperand.get(extendedSet).get(kind);
+                        operandInfo = spirv.ExtOperands.get(extendedSet).get(kind);
                     }
                     assert(operandInfo != undefined, 'Unknown grammar \'kind\' of ' + kind);
 
@@ -613,8 +613,8 @@ function parseBinaryStream(binary) {
         }
 
         // Handles all decorations and names
-        if (opcode == spirvEnum.Op.OpName) {
-            var name = getLiteralString(module.slice(i + 2, i + instructionLength));
+        if (opcode == spirv.Enums.Op.OpName) {
+            var name = spirv.getLiteralString(module.slice(i + 2, i + instructionLength));
             // strings can be empty according to specs definition of Literals
             // to prevent looking like a bug, replace with some more visual
             if (name == '') {
@@ -626,31 +626,31 @@ function parseBinaryStream(binary) {
 
         // Take Constant-Creation class opcodes and save const value to be displayed
         switch (opcode) {
-            case spirvEnum.Op.OpConstantTrue:
+            case spirv.Enums.Op.OpConstantTrue:
                 constantValues.set(module[i + 2], 'True');
                 break;
-            case spirvEnum.Op.OpConstantFalse:
+            case spirv.Enums.Op.OpConstantFalse:
                 constantValues.set(module[i + 2], 'False');
                 break;
-            case spirvEnum.Op.OpConstantNull:
+            case spirv.Enums.Op.OpConstantNull:
                 constantValues.set(module[i + 2], 'Null');
                 break;
-            case spirvEnum.Op.OpSpecConstantTrue:
+            case spirv.Enums.Op.OpSpecConstantTrue:
                 constantValues.set(module[i + 2], 'spec(True)');
                 break;
-            case spirvEnum.Op.OpSpecConstantFalse:
+            case spirv.Enums.Op.OpSpecConstantFalse:
                 constantValues.set(module[i + 2], 'spec(False)');
                 break;
             // value was found already above in LiteralContextDependentNumber check
-            case spirvEnum.Op.OpSpecConstant:
-            case spirvEnum.Op.OpConstant:
+            case spirv.Enums.Op.OpSpecConstant:
+            case spirv.Enums.Op.OpConstant:
             // not supported
-            case spirvEnum.Op.OpConstantComposite:
-            case spirvEnum.Op.OpConstantSampler:
-            case spirvEnum.Op.OpSpecConstantComposite:
-            case spirvEnum.Op.OpSpecConstantOp:
-            case spirvEnum.Op.OpConstantCompositeContinuedINTEL:
-            case spirvEnum.Op.OpSpecConstantCompositeContinuedINTEL:
+            case spirv.Enums.Op.OpConstantComposite:
+            case spirv.Enums.Op.OpConstantSampler:
+            case spirv.Enums.Op.OpSpecConstantComposite:
+            case spirv.Enums.Op.OpSpecConstantOp:
+            case spirv.Enums.Op.OpConstantCompositeContinuedINTEL:
+            case spirv.Enums.Op.OpSpecConstantCompositeContinuedINTEL:
                 break;
         };
 
@@ -674,16 +674,16 @@ function parseBinaryStream(binary) {
     instructionCount = 0;
 
     // Second pass
-    for (var i = 5; i < module.length;) {
-        var instruction = module[i];
-        var length = instruction >> spirvMeta.WordCountShift;
-        var opcode = instruction & spirvMeta.OpCodeMask;
+    for (let i = 5; i < module.length;) {
+        const instruction = module[i];
+        const length = instruction >> spirv.Meta.WordCountShift;
+        const opcode = instruction & spirv.Meta.OpCodeMask;
 
         var currentInstruction = instructionMap.get(instructionCount)
 
         // Add extra class to blocks for CFG
         switch (opcode) {
-            case spirvEnum.Op.OpLoopMerge:
+            case spirv.Enums.Op.OpLoopMerge:
                 var headerBlock = currentInstruction.block;
                 var mergeBlock = (instructionMap.get(resultToInstructionMap.get(module[i + 1]))).block;
                 var continueBlock = (instructionMap.get(resultToInstructionMap.get(module[i + 2]))).block;
@@ -700,14 +700,14 @@ function parseBinaryStream(binary) {
                 }
 
                 break;
-            case spirvEnum.Op.OpSelectionMerge:
+            case spirv.Enums.Op.OpSelectionMerge:
                 var headerBlock = currentInstruction.block;
                 var mergeBlock = (instructionMap.get(resultToInstructionMap.get(module[i + 1]))).block;
                 document.getElementById('label-' + headerBlock).className += (' selectionHeaderBlock-' + headerBlock);
                 document.getElementById('label-' + mergeBlock).className += (' selectionMergeBlock-' + headerBlock);
                 break;
-            case spirvEnum.Op.OpReturn:
-            case spirvEnum.Op.OpReturnValue:
+            case spirv.Enums.Op.OpReturn:
+            case spirv.Enums.Op.OpReturnValue:
                 var block = currentInstruction.block;
                 document.getElementById('label-' + block).className += ' returnBlock-' + block;
                 break;
@@ -716,8 +716,8 @@ function parseBinaryStream(binary) {
         // Holds all instructions that have resultID for each operand
         // store now instead of generating at DAG creation time
         // inverse of idConsumers
-        var parentInstructions = [];
-        var operandIdList = currentInstruction.operandIdList;
+        let parentInstructions = [];
+        const operandIdList = currentInstruction.operandIdList;
         for (let i = 0; i < operandIdList.length; i++) {
             parentInstructions.push(resultToInstructionMap.get(operandIdList[i]));
         }
@@ -879,7 +879,7 @@ function fillDagData(instruction, parents) {
     instructionFn.on('mouseout', instructionHover);
 
     var operation = instructionDiv.innerText;
-    var opcode = instructionDiv.getElementsByClassName('operation')[0].innerText;
+    const opcode = instructionDiv.getElementsByClassName('operation')[0].innerText;
     // remove starting instruction prefix and operands suffix
     operation = operation.substring(operation.indexOf(' ') + 1, operation.indexOf(opcode) + opcode.length);
 

--- a/source/spirv.js
+++ b/source/spirv.js
@@ -43,6 +43,18 @@ var spirv = {
     OpcodesWithResult : [],
 };
 
+const SPV_ENV_UNIVERSAL_1_0 = 0x00_01_00_00;
+const SPV_ENV_UNIVERSAL_1_1 = 0x00_01_01_00;
+const SPV_ENV_UNIVERSAL_1_2 = 0x00_01_02_00;
+const SPV_ENV_UNIVERSAL_1_3 = 0x00_01_03_00;
+const SPV_ENV_UNIVERSAL_1_4 = 0x00_01_04_00;
+const SPV_ENV_UNIVERSAL_1_5 = 0x00_01_05_00;
+const SPV_ENV_UNIVERSAL_1_6 = 0x00_01_06_00;
+const SPV_ENV_VULKAN_1_0 = 0x00_01_00_00;
+const SPV_ENV_VULKAN_1_1 = 0x00_01_01_00;
+const SPV_ENV_VULKAN_1_2 = 0x00_01_03_00;
+const SPV_ENV_VULKAN_1_3 = 0x00_01_05_00;
+
 // number of json files needed to be loaded
 var jsonRefCount = 0;
 const jsonRefTotal = 8;

--- a/source/spirv.js
+++ b/source/spirv.js
@@ -13,50 +13,40 @@
 // limitations under the License.
 'use strict';
 
-//
-// All logic related to dealing with SPIR-V concepts
-//
+var spirv = {
+    // When all the needed JSON grammar files load, let the UI know
+    JsonIsReady : false,
 
-// These are globals that hold subsets of the grammar file so it can be
-// more easily and efficiently accessed
-var spirvMeta = {};                // meta data for parsing
-var spirvVersion = 'Unknown';      // version of grammar file
-var spirvEnum = {};                // enum values for opcodes and operands
-var spirvInstruction = new Map();  // details information about opcodes
-var spirvOperand = new Map();      // details information about operands in 'operand_kinds' section
-var spirvExtInst = new Map();      // Same mapping as spirvInstruction, but for each grammar file
-var spirvExtOperand = new Map();   // Same mapping as spirvOperand, but for each grammar file
+    // Common Helper Functions/Utils
+    validateHeader : undefined,
+    getLiteralString : undefined,
 
-// TODO When #611 is resolved should not need this
-const ExtInstTypeGlslStd450 = 0;
-const ExtInstTypeOpenCLStd = 1;
-const ExtInstTypeNonSemanitcDebugPrintf = 2;
-const ExtInstTypeNonSemanitcClspvReflection = 3;
-const ExtInstTypeDebugInfo = 4;
-const ExtInstTypeOpenCLDebug100 = 5;
+    Version : "0.0.0",
+    Meta : {},
 
-spirvExtInst.set(ExtInstTypeGlslStd450, new Map());
-spirvExtInst.set(ExtInstTypeOpenCLStd, new Map());
-spirvExtInst.set(ExtInstTypeNonSemanitcDebugPrintf, new Map());
-spirvExtInst.set(ExtInstTypeNonSemanitcClspvReflection, new Map());
-spirvExtInst.set(ExtInstTypeDebugInfo, new Map());
-spirvExtInst.set(ExtInstTypeOpenCLDebug100, new Map());
+    Enums : {}, // enum values for opcodes and operands
+    Instructions : new Map(),  // details information about opcodes
+    Operands : new Map(), // details information about operands in 'operand_kinds' section
 
-// Not all extended sets have a mapping for operand kinds
-spirvExtOperand.set(ExtInstTypeOpenCLDebug100, new Map());
-spirvExtOperand.set(ExtInstTypeDebugInfo, new Map());
+    NameToOpcode : new Map(),  // [ 'OpCode' string : opcode number id ]
 
-// When all the needed JSON grammar files load, let the UI know
-var spirvJsonReady = false;
-var spirvJsonRefCount = 0;
+    ExtInstructions : new Map(), // Same mapping as Instructions, but for each grammar file
+    ExtOperands : new Map(),   // Same mapping as Operands, but for each grammar file
+    getExtInstructions : undefined,
+
+    OpcodesWithResultType : [],
+    OpcodesWithResult : [],
+};
+
 // number of json files needed to be loaded
-const spirvJsonRefTotal = 8;
+var jsonRefCount = 0;
+const jsonRefTotal = 8;
 
 function spirvJsonLoaded() {
-    spirvJsonRefCount++;
+    jsonRefCount++;
 
-    if (spirvJsonRefCount == spirvJsonRefTotal) {
-        spirvJsonReady = true;
+    if (jsonRefCount == jsonRefTotal) {
+        spirv.JsonIsReady = true;
 
         if (TEST_SUITE == true) {
             // Kick off test suite
@@ -77,113 +67,158 @@ function spirvJsonLoaded() {
             // Prompt user to select file
             document.getElementById('preLoad').style.display = 'none';
             document.getElementById('filePrompt').style.visibility = 'visible';
-            document.getElementById('spirvVersion').innerText = spirvVersion;
+            document.getElementById('spirvVersion').innerText = spirv.Version;
         }
     }
 }
 
-function loadSpirvJson() {
-    const spirvHeaderPath = 'SPIRV-Headers/include/spirv/unified1/'
+// TODO When internal SPIR-V spec issue #611 is resolved should not need this
+const ExtInstTypeGlslStd450 = 0;
+const ExtInstTypeOpenCLStd = 1;
+const ExtInstTypeNonSemanitcDebugPrintf = 2;
+const ExtInstTypeNonSemanitcClspvReflection = 3;
+const ExtInstTypeDebugInfo = 4;
+const ExtInstTypeOpenCLDebug100 = 5;
+
+spirv.getExtInstructions = function(extendedName) {
+    if (extendedName.includes("GLSL.std.450")) {
+        return spirv.ExtInstructions.get(ExtInstTypeGlslStd450);
+    } else if (extendedName.includes("OpenCL.std")) {
+        return spirv.ExtInstructions.get(ExtInstTypeOpenCLStd);
+    } else if (extendedName.includes("NonSemantic.DebugPrintf")) {
+        return spirv.ExtInstructions.get(ExtInstTypeNonSemanitcDebugPrintf);
+    } else if (extendedName.includes("NonSemantic.ClspvReflection")) {
+        return spirv.ExtInstructions.get(ExtInstTypeNonSemanitcClspvReflection);
+    } else if (extendedName.includes("DebugInfo")) {
+        return spirv.ExtInstructions.get(ExtInstTypeDebugInfo);
+    } else if (extendedName.includes("OpenCL.DebugInfo.100")) {
+        return spirv.ExtInstructions.get(ExtInstTypeOpenCLDebug100);
+    } else {
+        assert(false,'Full support for ' + extendedName + ' has not been added. Good chance things might break. Please report!');
+    }
+}
+
+function loadSpirvJson(grammarPath) {
     // C Header equivalent
-    $.getJSON(spirvHeaderPath + 'spirv.json', function(json) {
-        spirvMeta = json.spv.meta;
+    $.getJSON(grammarPath + 'spirv.json', function(json) {
+        spirv.Meta = json.spv.meta;
         for (let i = 0; i < json.spv.enum.length; i++) {
-            spirvEnum[json.spv.enum[i].Name] = json.spv.enum[i].Values;
+            spirv.Enums[json.spv.enum[i].Name] = json.spv.enum[i].Values;
         }
         spirvJsonLoaded();
     });
-    $.getJSON(spirvHeaderPath + 'spirv.core.grammar.json', function(json) {
-        spirvVersion = json.major_version + '.' + json.minor_version + '.' + json.revision;
+}
+
+function loadCoreGrammar(grammarPath) {
+    $.getJSON(grammarPath + 'spirv.core.grammar.json', function(json) {
+        spirv.Version = json.major_version + "." + json.minor_version + "." + json.revision;
         // put in map as need faster way to lookup then search large array each time
         for (let i = 0; i < json.instructions.length; i++) {
-            spirvInstruction.set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        for (let i = 0; i < json.operand_kinds.length; i++) {
-            spirvOperand.set(json.operand_kinds[i].kind, json.operand_kinds[i]);
-        }
-        spirvJsonLoaded();
-    });
+            const opcode = json.instructions[i].opcode;
+            spirv.NameToOpcode.set(json.instructions[i].opname, opcode)
+            spirv.Instructions.set(opcode, json.instructions[i]);
 
-    // Extended sets
-    // TODO - If loading speed becomes an issue, can load only when found in OpExtInstImport
-    $.getJSON(spirvHeaderPath + 'extinst.glsl.std.450.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeGlslStd450).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        spirvJsonLoaded();
-    });
-    $.getJSON(spirvHeaderPath + 'extinst.opencl.std.100.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeOpenCLStd).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        spirvJsonLoaded();
-    });
-    $.getJSON(spirvHeaderPath + 'extinst.nonsemantic.debugprintf.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeNonSemanitcDebugPrintf).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        spirvJsonLoaded();
-    });
-    $.getJSON(spirvHeaderPath + 'extinst.nonsemantic.clspvreflection.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeNonSemanitcClspvReflection).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        spirvJsonLoaded();
-    });
-    $.getJSON(spirvHeaderPath + 'extinst.debuginfo.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeDebugInfo).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        for (let i = 0; i < json.operand_kinds.length; i++) {
-            spirvExtOperand.get(ExtInstTypeDebugInfo).set(json.operand_kinds[i].kind, json.operand_kinds[i]);
-        }
-        spirvJsonLoaded();
-    });
-    $.getJSON(spirvHeaderPath + 'extinst.opencl.debuginfo.100.grammar.json', function(json) {
-        for (let i = 0; i < json.instructions.length; i++) {
-            spirvExtInst.get(ExtInstTypeOpenCLDebug100).set(json.instructions[i].opcode, json.instructions[i]);
-        }
-        for (let i = 0; i < json.operand_kinds.length; i++) {
-            spirvExtOperand.get(ExtInstTypeOpenCLDebug100).set(json.operand_kinds[i].kind, json.operand_kinds[i]);
-        }
-        spirvJsonLoaded();
-    });
-};
+            if (json.instructions[i].operands) {
+                // IdResultType is always first operand listed
+                if (json.instructions[i].operands[0].kind == "IdResultType") {
+                    spirv.OpcodesWithResultType.push(opcode);
+                }
 
-function opcodeHasResultType(opcode) {
-    let instructionInfo = spirvInstruction.get(opcode);
-    if (instructionInfo.operands) {
-        // IdResultType is always first operand listed
-        if (instructionInfo.operands[0].kind == 'IdResultType') {
-            return true;
-        }
-    }
-    return false;
-}
-
-function opcodeHasResult(opcode) {
-    let instructionInfo = spirvInstruction.get(opcode);
-    if (instructionInfo.operands) {
-        const checkOperands = Math.min(instructionInfo.operands.length, 2);
-        // IdResult is always first or second operand listed
-        for (let i = 0; i < checkOperands; i++) {
-            if (instructionInfo.operands[i].kind == 'IdResult') {
-                return true;
+                // IdResult is always first or second operand listed
+                const checkOperands = Math.min(json.instructions[i].operands.length, 2);
+                for (let j = 0; j < checkOperands; j++) {
+                    if (json.instructions[i].operands[j].kind == "IdResult") {
+                        spirv.OpcodesWithResult.push(opcode);
+                    }
+                }
             }
         }
-    }
-    return false;
+
+        for (let i = 0; i < json.operand_kinds.length; i++) {
+            spirv.Operands.set(json.operand_kinds[i].kind, json.operand_kinds[i]);
+        }
+        spirvJsonLoaded();
+    });
+}
+
+// Extended Instruction sets
+// Note: If loading speed becomes an issue, can load only when found in OpExtInstImport
+function loadExtInst(grammarPath) {
+    $.getJSON(grammarPath + 'extinst.glsl.std.450.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeGlslStd450, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeGlslStd450).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+        spirvJsonLoaded();
+    });
+
+    $.getJSON(grammarPath + 'extinst.opencl.std.100.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeOpenCLStd, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeOpenCLStd).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+        spirvJsonLoaded();
+    });
+
+    $.getJSON(grammarPath + 'extinst.nonsemantic.debugprintf.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeNonSemanitcDebugPrintf, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeNonSemanitcDebugPrintf).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+        spirvJsonLoaded();
+    });
+
+    $.getJSON(grammarPath + 'extinst.nonsemantic.clspvreflection.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeNonSemanitcClspvReflection, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeNonSemanitcClspvReflection).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+        spirvJsonLoaded();
+    });
+
+    $.getJSON(grammarPath + 'extinst.debuginfo.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeDebugInfo, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeDebugInfo).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+
+        spirv.ExtOperands.set(ExtInstTypeDebugInfo, new Map());
+        for (let i = 0; i < json.operand_kinds.length; i++) {
+            spirv.ExtOperands.get(ExtInstTypeDebugInfo).set(json.operand_kinds[i].kind, json.operand_kinds[i]);
+        }
+        spirvJsonLoaded();
+    });
+
+    $.getJSON(grammarPath + 'extinst.opencl.debuginfo.100.grammar.json', function(json) {
+        spirv.ExtInstructions.set(ExtInstTypeOpenCLDebug100, new Map());
+        for (let i = 0; i < json.instructions.length; i++) {
+            spirv.ExtInstructions.get(ExtInstTypeOpenCLDebug100).set(json.instructions[i].opcode, json.instructions[i]);
+        }
+
+        spirv.ExtOperands.set(ExtInstTypeOpenCLDebug100, new Map());
+        for (let i = 0; i < json.operand_kinds.length; i++) {
+            spirv.ExtOperands.get(ExtInstTypeOpenCLDebug100).set(json.operand_kinds[i].kind, json.operand_kinds[i]);
+        }
+        spirvJsonLoaded();
+    });
+}
+
+// Init into Loading SPIR-V grammar files
+function loadSpirv(spirvHeaderPath) {
+    loadSpirvJson(spirvHeaderPath);
+    loadCoreGrammar(spirvHeaderPath);
+    loadExtInst(spirvHeaderPath);
 }
 
 // @param header Uint32Array with 5 elements in it
-function validateHeader(header) {
-    assert(header[0] == spirvMeta.MagicNumber, 'Magic Number doesn\'t match, are you sure this is a binary SPIR-V file?');
-    assert(header[1] <= spirvMeta.Version, 'SPIR-V Headers are older than version of module');
+spirv.validateHeader = function(header) {
+    assert(header[0] == spirv.Meta.MagicNumber, 'Magic Number doesn\'t match, are you sure this is a binary SPIR-V file?');
+    assert(header[1] <= spirv.Meta.Version, 'SPIR-V Headers are older than version of module');
     assert(header[4] == 0, 'Only support schema 0 currently');
 }
 
 // @param words Slice of array of words in instruction
-function getLiteralString(words) {
+spirv.getLiteralString = function(words) {
     let result = '';
     for (let i = 0; i < words.length; i++) {
         let word = words[i];

--- a/style.css
+++ b/style.css
@@ -28,7 +28,11 @@ body {
     overflow: scroll;
 }
 
-#disassembleDiv {
+#disassembleInputDiv {
+    width: 42%; /* only seem to get 95% total to use */
+}
+
+#disassembleDisplayDiv {
     width: 42%; /* only seem to get 95% total to use */
 }
 


### PR DESCRIPTION
This does some cleanup and creates a proper SPIR-V object interface

Then added a `spirv-as` written in javascript so we can now paste text on the left at the start and have it parse it for us

For now, this is a one time usage, will need to think of UI to allow re-pasting without having to re-load