### PR TITLE
Fixed signed bitshift of instruction word count

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -111,7 +111,7 @@ function parseBinaryStream(binary) {
     // First pass
     for (let i = 5; i < module.length;) {
         const instruction = module[i];
-        const instructionLength = instruction >> spirv.Meta.WordCountShift;
+        const instructionLength = instruction >>> spirv.Meta.WordCountShift;
         const opcode = instruction & spirv.Meta.OpCodeMask;
 
         // Get type and result according to instruction layout
@@ -703,7 +703,7 @@ function parseBinaryStream(binary) {
     // Second pass
     for (let i = 5; i < module.length;) {
         const instruction = module[i];
-        const length = instruction >> spirv.Meta.WordCountShift;
+        const length = instruction >>> spirv.Meta.WordCountShift;
         const opcode = instruction & spirv.Meta.OpCodeMask;
 
         var currentInstruction = instructionMap.get(instructionCount)


### PR DESCRIPTION
SPIRV-Visualizer uses a signed bitshift of the instruction word count.
This results in incorrect values, e.g., when the word count for `OpSource` is `0xFF`. In this case, the value becomes `-1` instead of `0xFF`.